### PR TITLE
Added ability to stop the walk from descending into a given directory...

### DIFF
--- a/lib/node-type-emitter.js
+++ b/lib/node-type-emitter.js
@@ -49,7 +49,10 @@
     var flagSet;
 
     function nextWhenReady(flag) {
-      if (flag) { flagSet = flag; }
+      if (flag) {
+        stat.flag = flag;
+        flagSet = flag;
+      }
       num -= 1;
       if (0 === num) { next.call(self, flagSet); }
     }

--- a/lib/node-type-emitter.js
+++ b/lib/node-type-emitter.js
@@ -50,7 +50,7 @@
 
     function nextWhenReady(flag) {
       if (flag) {
-        stat.flag = flag;
+        stats.flag = flag;
         flagSet = flag;
       }
       num -= 1;

--- a/lib/walk.js
+++ b/lib/walk.js
@@ -15,6 +15,7 @@
 
   function appendToDirs(stat) {
     /*jshint validthis:true*/
+    if(stat.flag && stat.flag === NO_DESCEND) { return; }
     this.push(stat.name);
   }
 


### PR DESCRIPTION
…. You use this by calling `next(walk.NO_DESCEND)` in either the 'directory' or 'name' event handler. This will prevent the directory from being traversed.

This change allows the program to dynamically set when to descend or not descend for each directory. Here is a snippet that shows how to only walk the top level directory

``` javascript
var walk = require('walk');
var walker = walk.walk('/var/');

walker.on('file', function(root, stat, next) {
  console.log(root + '/' + stat.name);
  next();
});

walker.on('directory', function(root, stat, next) {
  console.log(root + '/' + stat.name);
  next(walk.NO_DESCEND);
});
```
